### PR TITLE
Changing pycrypto dependency with pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     print('pandoc is not installed.')
     read_md = lambda f: open(f, 'r').read()
 
-install_requires = ['pycrypto>=2.6.1']
+install_requires = ['pycryptodome>=3.4']
 if sys.version_info < (3, 3):
     install_requires.extend(['netaddr>=0.7.15'])
 

--- a/yacryptopan.py
+++ b/yacryptopan.py
@@ -49,7 +49,7 @@ class CryptoPAn(object):
                  are used for the AES key, and the latter for padding.
         """
         assert(len(key) == 32)
-        self._cipher = AES.new(key[:16])
+        self._cipher = AES.new(key[:16], AES.MODE_ECB)
         self._padding = array('B')
         if sys.version_info.major == 2:
             # for Python2


### PR DESCRIPTION
Hi, I made a modification to yacryptopan so that it uses [pycryptodome](http://pycryptodome.readthedocs.org/en/latest/src/introduction.html) as a dependency.

pycryptodome claims to be "_a self-contained Python package of low-level cryptographic primitives_" and "_it supports Python 2.4 or newer, all Python 3 versions and PyPy_". I made this change because I couldn't manage to install pycrypto with pypy on my system.

The functionality of yacryptopan is exactly the same. I only had to explicit the chaining mode (ECB, default) when creating the cipher.

I hope i was helpful. Thank you for your good work.
