### PR TITLE
Cleanup, Fixing, Python3, and Examples

### DIFF
--- a/anonymize_all_the_things.py
+++ b/anonymize_all_the_things.py
@@ -25,13 +25,15 @@ def print_std_err(str_):
     print(str_, file=sys.stderr)
 
 
-# Example: sompe IPv4 special purpose ranges
+# Example: sompe special purpose ranges
 SPECIAL_PURPOSE = [ip_network("10.0.0.0/8"),
                    ip_network("172.16.0.0/12"),
                    ip_network("192.0.0.0/24"),
                    ip_network("192.0.2.0/24"),
                    ip_network("192.168.0.0/16"),
-                   ip_network("224.0.0.0/4")]
+                   ip_network("224.0.0.0/4"),
+                   ip_network("2001:db8::/32") #IPv6 Address Prefix Reserved for Documentation
+                   ]
 
 def main(filename):
     global KEY

--- a/anonymize_all_the_things.py
+++ b/anonymize_all_the_things.py
@@ -42,7 +42,7 @@ fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|     # fe80::7:8%eth0   fe80::7:8%
 ([0-9a-fA-F]{1,4}:){1,7}:|                         # 1::                              1:2:3:4:5:6:7::
 :((:[0-9a-fA-F]{1,4}){1,7}|:)                     # ::2:3:4:5:6:7:8  ::2:3:4:5:6:7:8 ::8       ::     
 )""", re.X)
-    
+    mac_address = re.compile(r"""\s((?:[0-9a-fA-F]{2}:?){6})(?=\s)""") #enclosed in spaces, last space not consumed
     
     with open(filename, 'r') as fp:
         for line in fp:
@@ -55,6 +55,12 @@ fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|     # fe80::7:8%eth0   fe80::7:8%
                 ip = m.group(0)
                 ip_anonymized = cp.anonymize(ip)
                 line = line.replace(ip, ip_anonymized, 1)
+                
+            for m in mac_address.finditer(line):
+                mac = m.group(1) #does not include surrounding spaces
+                mac_anonymized = "XX:XX:XX:XX:XX:XX"
+                line = line.replace(mac, mac_anonymized, 1)
+                
             print(line.rstrip('\n'),)
                 
 

--- a/anonymize_all_the_things.py
+++ b/anonymize_all_the_things.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import absolute_import, division, print_function, unicode_literals
+#!/usr/bin/env python3
 from ipaddresscrypto import IPAddressCrypt, printStdErr
 from Crypto import Random #CSPSRNG
 from binascii import hexlify, unhexlify

--- a/anonymize_all_the_things.py
+++ b/anonymize_all_the_things.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-from ipaddresscrypto import IPAddressCrypt, printStdErr
+from ipaddresscrypto import IPAddressCrypt, print_std_err
 from Crypto import Random #CSPSRNG
 from binascii import hexlify, unhexlify
 import re, sys
 
-printStdErr("generating new random key.")
+print_std_err("generating new random key.")
 key = Random.new().read(32)
 # insert hard-coded key here
 #key = unhexlify('d70ae6667960559165d275c487624045eb8cc5c86ce20906dcc0521b7716089d')
-printStdErr("using key `%s'." % hexlify(key))
-printStdErr("save the key and hard-code it in this file to get reproducible results.")
+print_std_err("using key `%s'." % hexlify(key))
+print_std_err("save the key and hard-code it in this file to get reproducible results.")
 
 
 #this key triggers errors in my test data (mapping sth to special-purpose ranges):
@@ -19,7 +19,7 @@ printStdErr("save the key and hard-code it in this file to get reproducible resu
 cp = IPAddressCrypt(key)
 
 def main(filename):
-    printStdErr("opening %s" % filename)
+    print_std_err("opening %s" % filename)
 
     #http://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
     ipv4 = re.compile(r"""(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)""")
@@ -55,17 +55,17 @@ fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|     # fe80::7:8%eth0   fe80::7:8%
                 ip = m.group(0)
                 ip_anonymized = cp.anonymize(ip)
                 line = line.replace(ip, ip_anonymized, 1)
-                
+
             for m in mac_address.finditer(line):
                 mac = m.group(1) #does not include surrounding spaces
                 mac_anonymized = "XX:XX:XX:XX:XX:XX"
                 line = line.replace(mac, mac_anonymized, 1)
-                
+
             print(line.rstrip('\n'),)
 
 
 if len(sys.argv) != 2:
-    printStdErr("Usage: %s input_file_name > anonymized_output" % sys.argv[0])
+    print_std_err("Usage: %s input_file_name > anonymized_output" % sys.argv[0])
 else:
     main(sys.argv[1])
 

--- a/anonymize_all_the_things.py
+++ b/anonymize_all_the_things.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 """
-Example File
+Example File.
 Reads a text file with IP addresses and write an anomymized version to std out.
 Loopback addresses are not anomymized.
-Only the host part of private addresses gets randomized.
+Only the host part of some special purpose ranges gets anonymized.
 Censors MAC addresses, does not care whether IPv6 addresses have MAC addresses embedded.
 """
 

--- a/ipaddresscrypto.py
+++ b/ipaddresscrypto.py
@@ -24,7 +24,7 @@ class IPAddressCrypt(object):
     """
     def __init__(self, key):
         self.cp = CryptoPAn(key)
-    
+        
     def get_special_purpose_net(self, ip):
         ip = netaddr.IPAddress(ip)
         if ip.version == 4:
@@ -49,10 +49,15 @@ class IPAddressCrypt(object):
             #be super conservative and anonymize them all
     
     def __map_to_special_purpose_net(self, ip, special_net):
+        """Example:
+        
+        __map_to_special_purpose_net(netaddr.IPAddress("1.2.3.5"), netaddr.IPNetwork("192.168.0.0/16"))) = 192.168.3.5
+        __map_to_special_purpose_net(netaddr.IPAddress("1.2.3.5"), netaddr.IPNetwork("127.0.0.0/8"))) = 127.2.3.5
+        """
         #TODO: only support ipv4. there should be a library function for this?
         #assert that host-bits of net are all zero. Will fail for IPv6
         assert ((int(special_net.ip) << special_net.prefixlen) & 0xFFFFFFFF) == 0
-        ip = int(special_net.ip) + (int(netaddr.IPAddress(ip)) % 2^(32-special_net.prefixlen))
+        ip = int(special_net.ip) + (int(netaddr.IPAddress(ip)) % 2**(32-special_net.prefixlen))
         ip = netaddr.IPAddress(ip)
         return ip
     

--- a/ipaddresscrypto.py
+++ b/ipaddresscrypto.py
@@ -24,28 +24,54 @@ class IPAddressCrypt(object):
     """
     def __init__(self, key):
         self.cp = CryptoPAn(key)
+    
+    def get_special_purpose_net(self, ip):
+        ip = netaddr.IPAddress(ip)
+        if ip.version == 4:
+            for net in special_purpose_ipv4:
+                if ip in net:
+                    return net
+            return None
+        elif ip.version == 6:
+            #TODO
+            return None
+        assert False
         
-    def is_special_purpose_ipv4(self, ip):
-        for net in special_purpose_ipv4:
-            if ip in net:
-                return True
-        return False
+    def is_special_purpose(self, ip):
+        return (self.get_special_purpose_net(ip) is not None)
     
     def do_not_anonymize(self, ip):
         ip = netaddr.IPAddress(ip)
         if ip.version == 4:
-            return self.is_special_purpose_ipv4(ip)
+            return self.is_special_purpose(ip)
         else:
             return False #IPv6 addresses can have MACs embedded
             #be super conservative and anonymize them all
-        
+    
+    def __map_to_special_purpose_net(self, ip, special_net):
+        #TODO: only support ipv4. there should be a library function for this?
+        #assert that host-bits of net are all zero. Will fail for IPv6
+        assert ((int(special_net.ip) << special_net.prefixlen) & 0xFFFFFFFF) == 0
+        ip = int(special_net.ip) + (int(netaddr.IPAddress(ip)) % 2^(32-special_net.prefixlen))
+        ip = netaddr.IPAddress(ip)
+        return ip
+    
     def anonymize(self, ip):
         if self.do_not_anonymize(ip):
             #TODO anonymize but completely keep the prefix (i.e. only anonymize the least significant bits)
             return ip
         else:
             ip_anonymized = self.cp.anonymize(ip)
-            if self.do_not_anonymize(ip_anonymized):
-                #TODO: anonymize again until we are in a `good` range?
-                printStdErr("WARNING: anonymized ip address mapped to special-purpose address range. Please consider re-running with different key")
+            # if anonymized IP is accidentally mapped into a special purpose 
+            # range, try to map it to a different range
+            if self.is_special_purpose(ip_anonymized):
+                printStdErr("INFO: anonymized ip %s mapped to "
+                            "special-purpose address range. retrying" % ip)
+                #anonymize once again
+                ip_anonymized = self.cp.anonymize(ip_anonymized)
+                if self.is_special_purpose(ip_anonymized):
+                    printStdErr("WARNING: anonymized ip address mapped to "
+                                "special-purpose address range. Please consider "
+                                "re-running with different key")
             return ip_anonymized
+

--- a/ipaddresscrypto.py
+++ b/ipaddresscrypto.py
@@ -1,21 +1,19 @@
-#!/usr/bin/env python
-from __future__ import absolute_import, division, print_function, unicode_literals
+#!/usr/bin/env python3
 import sys
-import netaddr
+import ipaddress
 from yacryptopan import CryptoPAn
-import netaddr
 
-def printStdErr(*objs):
-    print(*objs, file=sys.stderr)
+def printStdErr(s):
+    print(s, file=sys.stderr)
 
 
-special_purpose_ipv4 = [netaddr.IPNetwork("10.0.0.0/8"),
-                        netaddr.IPNetwork("127.0.0.0/8"),
-                        netaddr.IPNetwork("172.16.0.0/12"),
-                        netaddr.IPNetwork("192.0.0.0/24"),
-                        netaddr.IPNetwork("192.0.2.0/24"),
-                        netaddr.IPNetwork("192.168.0.0/16"),
-                        netaddr.IPNetwork("224.0.0.0/4")]
+special_purpose_ipv4 = [ipaddress.ip_network("10.0.0.0/8"),
+                        ipaddress.ip_network("127.0.0.0/8"),
+                        ipaddress.ip_network("172.16.0.0/12"),
+                        ipaddress.ip_network("192.0.0.0/24"),
+                        ipaddress.ip_network("192.0.2.0/24"),
+                        ipaddress.ip_network("192.168.0.0/16"),
+                        ipaddress.ip_network("224.0.0.0/4")]
 
 #TODO inherit CryptoPAn?
 class IPAddressCrypt(object):
@@ -26,7 +24,7 @@ class IPAddressCrypt(object):
         self.cp = CryptoPAn(key)
         
     def get_special_purpose_net(self, ip):
-        ip = netaddr.IPAddress(ip)
+        ip = ipaddress.ip_address(ip)
         if ip.version == 4:
             for net in special_purpose_ipv4:
                 if ip in net:
@@ -41,7 +39,7 @@ class IPAddressCrypt(object):
         return (self.get_special_purpose_net(ip) is not None)
     
     def do_not_anonymize(self, ip):
-        ip = netaddr.IPAddress(ip)
+        ip = ipaddress.ip_address(ip)
         if ip.version == 4:
             return self.is_special_purpose(ip)
         else:
@@ -51,14 +49,14 @@ class IPAddressCrypt(object):
     def __map_to_special_purpose_net(self, ip, special_net):
         """Example:
         
-        __map_to_special_purpose_net(netaddr.IPAddress("1.2.3.5"), netaddr.IPNetwork("192.168.0.0/16"))) = 192.168.3.5
-        __map_to_special_purpose_net(netaddr.IPAddress("1.2.3.5"), netaddr.IPNetwork("127.0.0.0/8"))) = 127.2.3.5
+        __map_to_special_purpose_net(ipaddress.IPAddress("1.2.3.5"), ipaddress.ip_network("192.168.0.0/16"))) = 192.168.3.5
+        __map_to_special_purpose_net(ipaddress.IPAddress("1.2.3.5"), ipaddress.ip_network("127.0.0.0/8"))) = 127.2.3.5
         """
         #TODO: only support ipv4. there should be a library function for this?
         #assert that host-bits of net are all zero. Will fail for IPv6
         assert ((int(special_net.ip) << special_net.prefixlen) & 0xFFFFFFFF) == 0
-        ip = int(special_net.ip) + (int(netaddr.IPAddress(ip)) % 2**(32-special_net.prefixlen))
-        ip = netaddr.IPAddress(ip)
+        ip = int(special_net.ip) + (int(ipaddress.IPAddress(ip)) % 2**(32-special_net.prefixlen))
+        ip = ipaddress.IPAddress(ip)
         return ip
 
     def anonymize(self, ip):

--- a/ipaddresscrypto.py
+++ b/ipaddresscrypto.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Example File
+Example File.
 A wrapper around CryptoPAn with some (probably unsound) features. It anonymizes
 IP addresses, but there is an option not to anonymize certain IP addresses
 or to preserve the prefix for certain ranges.

--- a/test.py
+++ b/test.py
@@ -317,8 +317,8 @@ class Examples(unittest.TestCase):
         ret = subprocess.run([sys.executable, example_prog, 'testdata/nasty.txt', key], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.assertEqual(ret.returncode, 0)
         expected = b"""foobar 117.8.135.123
-v6foobar 1f18:bc7b:945c:69f8:241f:9dd1:fb4e:ff79 foo 1f18:bc7b:945c:69f8:241f:9dd1:fb4e:ff79 foooshorter 1f18:bc7b:945c:69f8:241f:9dd1:fb4e:ff79 even shorter 1f18:bc7b:945c:69f8:241f:9dd1:fb4e:ff79
-ipv6 url http://[1f18:bc7b:945c:669b:2e19:9a2e:377:6486]:8080/
+v6foobar 1482:f447:75b3:f1f9:fbdf:622e:34f:ff7b foo 1482:f447:75b3:f1f9:fbdf:622e:34f:ff7b foooshorter 1482:f447:75b3:f1f9:fbdf:622e:34f:ff7b even shorter 1482:f447:75b3:f1f9:fbdf:622e:34f:ff7b
+ipv6 url http://[1482:f447:75b3:f904:c1d9:ba2e:489:1346]:8080/
 -A FORWARD -d 162.112.255.43/19 -s 162.112.255.43/19 -j ACCEPT
 -A OUTPUT -d 55.21.62.136 -j ACCEPT
 -A INPUT -s 240.232.0.156/32 -m iprange ! --src-range 56.131.176.115-240.15.248.0
@@ -331,7 +331,7 @@ IPv6 address which looks almost like a MAC: 1f18:b37b:1cc3:8118:41f:9fd1:f875:fa
 ipv4 embedded ipv6 3883:b073:ff0f:fff8:203f:7c8:617:fd01
 a line with no IP addresses
 f33c:8ca3:ef0f:e019:e7ff:f1e3:f91f:f800/7 f33c:8ca3:ef0f:e019:e7ff:f1e3:f91f:f800
-1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff
+2001:db8:e01:891e:401:3:f8fb:44ff 2001:db8:e01:891e:401:3:f8fb:44ff 2001:db8:e01:891e:401:3:f8fb:44ff 2001:db8:e01:891e:401:3:f8fb:44ff 2001:db8:e01:891e:401:3:f8fb:44ff 2001:db8:e01:891e:401:3:f8fb:44ff 2001:db8:e01:891e:401:3:f8fb:44ff 2001:db8:e01:891e:401:3:f8fb:44ff
 """
         self.assertEqual(ret.stdout, expected)
 

--- a/test.py
+++ b/test.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 from __future__ import absolute_import, division, print_function, unicode_literals
+import sys, os
 import unittest
 import random
+import subprocess
 from yacryptopan import CryptoPAn
-import sys
 if sys.version_info < (3, 3):
     # python 2 compatibility
     import netaddr
@@ -306,5 +307,35 @@ class ReferenceImplementationIPv4(unittest.TestCase):
 
     # further test TODO
     # test all tests which only do prefix_preserving with random key again
+
+
+@unittest.skipUnless(sys.version_info > (3, 4), "Examples require at least python 3")
+class Examples(unittest.TestCase):
+    def test_anonymize_all_the_things(self):
+        example_prog = "./anonymize_all_the_things.py"
+        key = '8009ab3a605435bea0c385bea18485d8b0a1103d6590bdf48c968be5de53836e'
+        self.assertTrue(os.path.isfile(example_prog) )
+        ret = subprocess.run([sys.executable, example_prog, 'testdata/nasty.txt', key], stdout=subprocess.PIPE)
+        self.assertEqual(ret.returncode, 0)
+        expected = b"""foobar 117.8.135.123
+v6foobar 1f18:bc7b:945c:69f8:241f:9dd1:fb4e:ff79 foo 1f18:bc7b:945c:69f8:241f:9dd1:fb4e:ff79 foooshorter 1f18:bc7b:945c:69f8:241f:9dd1:fb4e:ff79 even shorter 1f18:bc7b:945c:69f8:241f:9dd1:fb4e:ff79
+ipv6 url http://[1f18:bc7b:945c:669b:2e19:9a2e:377:6486]:8080/
+-A FORWARD -d 162.112.255.43/19 -s 162.112.255.43/19 -j ACCEPT
+-A OUTPUT -d 55.21.62.136 -j ACCEPT
+-A INPUT -s 240.232.0.156/32 -m iprange ! --src-range 56.131.176.115-240.15.248.0
+special purpose v4: 127.0.4.5 192.168.141.101 10.92.194.88
+special v6: :: ::1 ::
+do not anonymize mac addresses
+ HWaddr XX:XX:XX:XX:XX:XX XX:XX:XX:XX:XX:XX  foo
+ HWaddr with line ending XX:XX:XX:XX:XX:XX
+IPv6 address which looks almost like a MAC: 1f18:b37b:1cc3:8118:41f:9fd1:f875:fab8
+ipv4 embedded ipv6 3883:b073:ff0f:fff8:203f:7c8:617:fd01
+a line with no IP addresses
+f33c:8ca3:ef0f:e019:e7ff:f1e3:f91f:f800/7 f33c:8ca3:ef0f:e019:e7ff:f1e3:f91f:f800
+1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff 1f18:bc7b:e01:891e:401:3:f8fb:44ff
+"""
+        self.assertEqual(ret.stdout, expected)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/testdata/nasty.txt
+++ b/testdata/nasty.txt
@@ -1,6 +1,6 @@
 foobar 123.123.123.123
-v6foobar 2001:0db8:85a3:0000:0000:8a2e:0370:7344 foo 2001:0db8:85a3:0000:0000:8a2e:0370:7344 foooshorter 2001:db8:85a3:0:0:8a2e:370:7344 even shorter 2001:db8:85a3::8a2e:370:7344
-ipv6 url http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080/
+v6foobar 2a02:0db8:85a3:0000:0000:8a2e:0370:7344 foo 2a02:0db8:85a3:0000:0000:8a2e:0370:7344 foooshorter 2a02:db8:85a3:0:0:8a2e:370:7344 even shorter 2a02:db8:85a3::8a2e:370:7344
+ipv6 url http://[2a02:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080/
 -A FORWARD -d 131.159.1.42/19 -s 131.159.1.42/19 -j ACCEPT
 -A OUTPUT -d 8.8.8.8 -j ACCEPT
 -A INPUT -s 255.8.1.100/32 -m iprange ! --src-range 0.0.0.0-255.255.255.255

--- a/testdata/nasty.txt
+++ b/testdata/nasty.txt
@@ -4,7 +4,8 @@ ipv6 url http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080/
 -A FORWARD -d 131.159.1.42/19 -s 131.159.1.42/19 -j ACCEPT
 -A OUTPUT -d 8.8.8.8 -j ACCEPT
 -A INPUT -s 255.8.1.100/32 -m iprange ! --src-range 0.0.0.0-255.255.255.255
-special purpose v4: 127.0.4.5
+special purpose v4: 127.0.4.5 192.168.42.42 10.0.0.0
+special v6: :: ::1 0:0::0
 do not anonymize mac addresses
  HWaddr ab:ab:ab:ab:ab:ab FF:FF:FF:FF:FF:FF  foo
  HWaddr with line ending ab:ab:ab:ab:ab:ab

--- a/testdata/nasty.txt
+++ b/testdata/nasty.txt
@@ -1,0 +1,14 @@
+foobar 123.123.123.123
+v6foobar 2001:0db8:85a3:0000:0000:8a2e:0370:7344 foo 2001:0db8:85a3:0000:0000:8a2e:0370:7344 foooshorter 2001:db8:85a3:0:0:8a2e:370:7344 even shorter 2001:db8:85a3::8a2e:370:7344
+ipv6 url http://[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:8080/
+-A FORWARD -d 131.159.1.42/19 -s 131.159.1.42/19 -j ACCEPT
+-A OUTPUT -d 8.8.8.8 -j ACCEPT
+-A INPUT -s 255.8.1.100/32 -m iprange ! --src-range 0.0.0.0-255.255.255.255
+special purpose v4: 127.0.4.5
+do not anonymize mac addresses
+ HWaddr ab:ab:ab:ab:ab:ab FF:FF:FF:FF:FF:FF  foo
+ HWaddr with line ending ab:ab:ab:ab:ab:ab
+ipv4 embedded ipv6 ::ffff:192.0.2.128
+a line with no IP addresses
+fc00::/7 fc00::
+2001:db8:0:0:1:0:0:1 2001:0db8:0:0:1:0:0:1 2001:db8::1:0:0:1 2001:db8::0:1:0:0:1 2001:0db8::1:0:0:1 2001:db8:0:0:1::1 2001:db8:0000:0:1::1 2001:DB8:0:0:1::1

--- a/testdata/nasty.txt
+++ b/testdata/nasty.txt
@@ -9,6 +9,7 @@ special v6: :: ::1 0:0::0
 do not anonymize mac addresses
  HWaddr ab:ab:ab:ab:ab:ab FF:FF:FF:FF:FF:FF  foo
  HWaddr with line ending ab:ab:ab:ab:ab:ab
+IPv6 address which looks almost like a MAC: 2001:b8:a3:00:00:2e:70:44
 ipv4 embedded ipv6 ::ffff:192.0.2.128
 a line with no IP addresses
 fc00::/7 fc00::

--- a/yacryptopan.py
+++ b/yacryptopan.py
@@ -44,16 +44,16 @@ class CryptoPAn(object):
         """Initialize a CryptoPAn() instance.
 
         Args:
-            key: a 32 bytes string used for AES key and padding when
+            key: a 32 bytes object used for AES key and padding when
                  performing a block cipher operation. The first 16 bytes
                  are used for the AES key, and the latter for padding.
+
+        Changelog: A bytes object (not string) is required for python3.
         """
         assert(len(key) == 32)
-        if sys.version_info.major == 3:
-            # XXX what is this?
-            # XXX encode the key string to a byte array.
-            # XXX key = key.encode('utf-8')
-            # XXX incompatibility to previous version!!
+        if sys.version_info.major < 3:
+            assert type(key) is str
+        else:
             assert type(key) is bytes
         self._cipher = AES.new(key[:16], AES.MODE_ECB)
         self._padding = array('B')

--- a/yacryptopan.py
+++ b/yacryptopan.py
@@ -50,8 +50,11 @@ class CryptoPAn(object):
         """
         assert(len(key) == 32)
         if sys.version_info.major == 3:
-            # encode the key string to a byte array.
-            key = key.encode('utf-8')
+            # XXX what is this?
+            # XXX encode the key string to a byte array.
+            # XXX key = key.encode('utf-8')
+            # XXX incompatibility to previous version!!
+            assert type(key) is bytes
         self._cipher = AES.new(key[:16], AES.MODE_ECB)
         self._padding = array('B')
         if sys.version_info.major == 2:


### PR DESCRIPTION
The examples (`anonymize_all_the_things.py` and `ipaddresscrypto.py`) should have never made it into the master branch :man_facepalming:. Now they are there, so I took care of them:
 * Ported to python 3
 * Cleanup and refactoring
 * `anonymize_all_the_things.py` distinguishes between MAC addresses and IPv6 addresses
 * `ipaddresscrypto.py`
   * now uses the python3 `ipaddress` module
   * does not anonymize loopback addresses or `::` (configurable)
   * has an option to only anonymize the host part of some address ranges
   * is no longer full of TODOs

The test suite now passes on python2 and python3

**Breaking change**:
CryptoPAn now expects the key to be a bytes object in python3.

Sorry for the merge in the middle of the git history :crying_cat_face: 